### PR TITLE
Replace object pointer tagging with info table tagging

### DIFF
--- a/include/yave/rts/apply.hpp
+++ b/include/yave/rts/apply.hpp
@@ -94,6 +94,30 @@ namespace yave {
   /// runtime apply object
   using Apply = Box<apply_object_value>;
 
+  // Apply 
+  YAVE_DECL_TYPE(yave::Apply, "2db5ddcd-0d6d-4f2f-8fd5-7b30abfc68eb");
+
+  // tagged info table
+  template <>
+  struct Apply::info_table_initializer
+  {
+    /// get info table pointer
+    static const object_info_table* get_info_table()
+    {
+      // add apply tag
+      return detail::add_apply_tag(&info_table);
+    }
+
+  private:
+    /// static object info table
+    alignas(32) inline static const object_info_table info_table {
+      object_type<Apply>(),            //
+      sizeof(Apply),                   //
+      object_type_traits<Apply>::name, //
+      vtbl_destroy_func<Apply>,        //
+      vtbl_clone_func<Apply>};         //
+  };
+
   /// compile time apply object
   template <class App, class Arg>
   struct TApply : Apply
@@ -165,6 +189,3 @@ namespace yave {
   }
 
 } // namespace yave
-
-// Apply
-YAVE_DECL_TYPE(yave::Apply, "2db5ddcd-0d6d-4f2f-8fd5-7b30abfc68eb");

--- a/include/yave/rts/box_fwd.hpp
+++ b/include/yave/rts/box_fwd.hpp
@@ -108,7 +108,7 @@ namespace yave {
         !std::is_same_v<std::decay_t<U>, static_construct_t>>>
     constexpr Box(U &&u, Args &&... args) //
       noexcept(std::is_nothrow_constructible_v<T, U, Args...>)
-      : Object {&info_table_initializer::info_table}
+      : Object {info_table_initializer::get_info_table()}
       , m_value {std::forward<U>(u), std::forward<Args>(args)...}
     {
     }
@@ -126,7 +126,7 @@ namespace yave {
     /// Ctor
     constexpr Box() //
       noexcept(std::is_nothrow_constructible_v<T>)
-      : Object {&info_table_initializer::info_table}
+      : Object {info_table_initializer::get_info_table()}
       , m_value {}
     {
     }
@@ -134,7 +134,7 @@ namespace yave {
     /// Copy ctor
     constexpr Box(const Box &obj) //
       noexcept(std::is_nothrow_copy_constructible_v<T>)
-      : Object {&info_table_initializer::info_table}
+      : Object {info_table_initializer::get_info_table()}
       , m_value {obj.m_value}
     {
     }
@@ -142,7 +142,7 @@ namespace yave {
     /// Move ctor
     constexpr Box(Box &&obj) //
       noexcept(std::is_nothrow_move_constructible_v<T>)
-      : Object {&info_table_initializer::info_table}
+      : Object {info_table_initializer::get_info_table()}
       , m_value {std::move(obj.m_value)}
     {
     }
@@ -186,6 +186,13 @@ namespace yave {
       // check m_value's offset
       static_assert(offset_of_member(&Box::m_value) == sizeof(Object));
 
+      /// get info table pointer
+      static constexpr const object_info_table *get_info_table()
+      {
+        return &info_table;
+      }
+
+    private:
       /// static object info table
       alignas(32) inline static const object_info_table info_table {
         object_type<Box>(),            //

--- a/include/yave/rts/eval.hpp
+++ b/include/yave/rts/eval.hpp
@@ -142,9 +142,8 @@ namespace yave {
           stack.erase(base_iter, stack.end());
 
           // detect exception
-          if (unlikely(has_exception_tag(result)))
-            throw result_error::exception_result(
-              clear_pointer_tag(get_tagged_exception(result)));
+          if (auto excpt = value_cast_if<Exception>(result))
+            throw result_error::exception_result(excpt);
 
           // completed
           if (stack.empty())

--- a/include/yave/rts/exception.hpp
+++ b/include/yave/rts/exception.hpp
@@ -44,6 +44,29 @@ namespace yave {
   /// Exception
   using Exception = Box<exception_object_value>;
 
+  // Exception
+  YAVE_DECL_TYPE(yave::Exception, "1a30465c-ee14-473e-bcb9-5ef2462d933f");
+
+  // info table tag
+  template <>
+  struct Exception::info_table_initializer
+  {
+    /// get info table pointer
+    static const object_info_table* get_info_table()
+    {
+      return detail::add_exception_tag(&info_table);
+    }
+
+  private:
+    /// static object info table
+    alignas(32) inline static const object_info_table info_table {
+      object_type<Exception>(),            //
+      sizeof(Exception),                   //
+      object_type_traits<Exception>::name, //
+      vtbl_destroy_func<Exception>,        //
+      vtbl_clone_func<Exception>};         //
+  };
+
   // ------------------------------------------
   // conversion
 
@@ -54,6 +77,3 @@ namespace yave {
   }
 
 } // namespace yave
-
-// Exception
-YAVE_DECL_TYPE(yave::Exception, "1a30465c-ee14-473e-bcb9-5ef2462d933f");

--- a/include/yave/rts/exception.hpp
+++ b/include/yave/rts/exception.hpp
@@ -45,31 +45,6 @@ namespace yave {
   using Exception = Box<exception_object_value>;
 
   // ------------------------------------------
-  // helper
-
-  template <class T>
-  [[nodiscard]] inline auto add_exception_tag(object_ptr<T> e) noexcept
-    -> object_ptr<T>
-  {
-    _get_storage(e).set_pointer_tag(
-      object_ptr_storage::pointer_tags::exception);
-    return e;
-  }
-
-  [[nodiscard]] inline bool has_exception_tag(
-    const object_ptr<const Object>& obj) noexcept
-  {
-    return _get_storage(obj).is_exception();
-  }
-
-  [[nodiscard]] inline auto get_tagged_exception(
-    const object_ptr<const Object>& obj) noexcept -> object_ptr<const Exception>
-  {
-    assert(has_exception_tag(obj));
-    return static_object_cast<const Exception>(obj);
-  }
-
-  // ------------------------------------------
   // conversion
 
   [[nodiscard]] inline auto to_Exception(const std::exception& e)

--- a/include/yave/rts/function.hpp
+++ b/include/yave/rts/function.hpp
@@ -57,52 +57,48 @@ namespace yave {
 
         // type_error
       } catch (const bad_value_cast& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
 
         // type_error
       } catch (const type_error::circular_constraint& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const type_error::type_missmatch& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const type_error::bad_type_check& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const type_error::type_error& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
 
         // result_error
       } catch (const result_error::exception_result& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const result_error::result_error& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
 
         // eval_error
       } catch (const eval_error::bad_fix& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const eval_error::bad_apply& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const eval_error::too_many_arguments& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
       } catch (const eval_error::eval_error& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
 
         // std::exception
       } catch (const std::exception& e) {
-        return add_exception_tag(to_Exception(e));
+        return to_Exception(e);
 
         // unknown
       } catch (...) {
-        return add_exception_tag(make_object<Exception>(
+        return make_object<Exception>(
           make_object<String>("Unknown exception thrown while evaluation"),
-          object_ptr(nullptr)));
+          object_ptr(nullptr));
       }
     }();
 
     // vtbl_code_func should not return Undefined value
     assert(ret);
-
-    // exception object retuned fron vtbl_code_func should have pointer tag
-    if (!has_exception_tag(ret))
-      assert(!value_cast_if<Exception>(ret));
 
     return ret;
   }
@@ -188,14 +184,12 @@ namespace yave {
     exception_handler_return_type_checker(object_ptr<U> e) noexcept
       : m_value {object_ptr<const Exception>(std::move(e))}
     {
-      m_value = add_exception_tag(std::move(m_value));
     }
 
     /// Exception ctor
     exception_handler_return_type_checker(const Exception* e) noexcept
       : exception_handler_return_type_checker(object_ptr(e))
     {
-      m_value = add_exception_tag(std::move(m_value));
     }
 
     // deleted

--- a/include/yave/rts/info_table_tags.hpp
+++ b/include/yave/rts/info_table_tags.hpp
@@ -25,8 +25,7 @@ namespace yave {
       //                        ^^^^^^^^^^
       vanilla      = 0,
       exception    = 1,                  // Exception
-      apply        = 2,                  // ApplyR
-      function     = 3,                  // Function<T, Ts...>
+      apply        = 2,                  // Apply
       extract_mask = 0x0000000000000007, // 0...0111
       clear_mask   = 0xFFFFFFFFFFFFFFF8, // 1...1000
     };
@@ -96,17 +95,5 @@ namespace yave {
       return check_info_table_tag(tagged, info_table_tags::apply);
     }
 
-    // Function
-
-    [[nodiscard]] inline const object_info_table* add_function_tag(
-      const object_info_table* info)
-    {
-      return add_info_table_tag(info, info_table_tags::function);
-    }
-
-    [[nodiscard]] inline bool has_function_tag(const object_info_table* tagged)
-    {
-      return check_info_table_tag(tagged, info_table_tags::function);
-    }
   } // namespace detail
 } // namespace yave

--- a/include/yave/rts/info_table_tags.hpp
+++ b/include/yave/rts/info_table_tags.hpp
@@ -1,0 +1,112 @@
+//
+// Copyright (c) 2019 mocabe (https://github.com/mocabe)
+// Distributed under LGPLv3 License. See LICENSE for more details.
+//
+
+#pragma once
+
+#include <yave/config/config.hpp>
+#include <cstring>
+
+namespace yave {
+
+  // fwd
+  struct object_info_table;
+
+  namespace detail {
+
+    // Info table pointer tags.
+    // Uses lowest 3 bits of info table pointer.
+    enum class info_table_tags : uintptr_t
+    {
+      // h <---------------------> l
+      //                        |<>|
+      //                        tag (3bit)
+      //                        ^^^^^^^^^^
+      vanilla      = 0,
+      exception    = 1,                  // Exception
+      apply        = 2,                  // ApplyR
+      function     = 3,                  // Function<T, Ts...>
+      extract_mask = 0x0000000000000007, // 0...0111
+      clear_mask   = 0xFFFFFFFFFFFFFFF8, // 1...1000
+    };
+
+    /// Add info table tag of type T to given pointer.
+    [[nodiscard]] inline const object_info_table* add_info_table_tag(
+      const object_info_table* ptr,
+      info_table_tags tag)
+    {
+      uintptr_t tmp = 0;
+      std::memcpy(&tmp, &ptr, sizeof(ptr));
+
+      tmp |= static_cast<uintptr_t>(tag);
+
+      const object_info_table* ret = nullptr;
+      std::memcpy(&ret, &tmp, sizeof(ret));
+      return ret;
+    }
+
+    /// Clear info table pointer tag and get actual address
+    [[nodiscard]] inline const object_info_table* clear_info_table_tag(
+      const object_info_table* tagged)
+    {
+      uintptr_t tmp = 0;
+      std::memcpy(&tmp, &tagged, sizeof(tagged));
+
+      tmp &= static_cast<uintptr_t>(info_table_tags::clear_mask);
+
+      const object_info_table* ret = nullptr;
+      std::memcpy(&ret, &tmp, sizeof(ret));
+      return ret;
+    }
+
+    /// Check if info table pointer has tag value of type T.
+    [[nodiscard]] inline bool check_info_table_tag(
+      const object_info_table* tagged,
+      info_table_tags tag)
+    {
+      uintptr_t tmp = 0;
+      std::memcpy(&tmp, &tagged, sizeof(tagged));
+      return tmp & static_cast<uintptr_t>(tag);
+    }
+
+    // Exception
+
+    [[nodiscard]] inline const object_info_table* add_exception_tag(
+      const object_info_table* info)
+    {
+      return add_info_table_tag(info, info_table_tags::exception);
+    }
+
+    [[nodiscard]] inline bool has_exception_tag(const object_info_table* tagged)
+    {
+      return check_info_table_tag(tagged, info_table_tags::exception);
+    }
+
+    // Apply
+
+    [[nodiscard]] inline const object_info_table* add_apply_tag(
+      const object_info_table* info)
+    {
+      return add_info_table_tag(info, info_table_tags::apply);
+    }
+
+    [[nodiscard]] inline bool has_apply_tag(const object_info_table* tagged)
+    {
+      return check_info_table_tag(tagged, info_table_tags::apply);
+    }
+
+    // Function
+
+    [[nodiscard]] inline const object_info_table* add_function_tag(
+      const object_info_table* info)
+    {
+      return add_info_table_tag(info, info_table_tags::function);
+    }
+
+    [[nodiscard]] inline bool has_function_tag(const object_info_table* tagged)
+    {
+      return check_info_table_tag(tagged, info_table_tags::function);
+    }
+  } // namespace detail
+} // namespace yave

--- a/include/yave/rts/object_ptr.hpp
+++ b/include/yave/rts/object_ptr.hpp
@@ -406,15 +406,4 @@ namespace yave {
     return object_ptr<T>(new T(std::forward<Args>(args)...));
   }
 
-  // ------------------------------------------
-  // misc
-
-  template <class T>
-  [[nodiscard]] auto clear_pointer_tag(object_ptr<T> obj) noexcept
-    -> object_ptr<T>
-  {
-    _get_storage(obj).clear_pointer_tag();
-    return obj;
-  }
-
 } // namespace yave

--- a/include/yave/rts/object_ptr_storage.hpp
+++ b/include/yave/rts/object_ptr_storage.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <yave/rts/object.hpp>
+#include <yave/rts/info_table_tags.hpp>
 
 #include <cstring>
 
@@ -16,66 +17,11 @@ namespace yave {
   /// internal storage of object_ptr
   struct object_ptr_storage
   {
-    /// pointer tag values. stored in lowest 3 bits of 64bit data.
-    enum class pointer_tags : uint64_t
-    {
-      // clang-format off
-
-      // h <---------------------> l
-      //                        |<>|
-      //                        tag (3bit)
-      //                        ^^^^^^^^^^
-
-      pointer   = 0x0, //< plain pointer
-      exception = 0x1, //< exception returned from vtbl_code_func
-
-      extract_mask = 0x0000000000000007, // 0...0111
-      clear_mask   = 0xFFFFFFFFFFFFFFF8, // 1...1000
-
-      // clang-format on
-    };
-
-    /// extract pointer tag flag
-    [[nodiscard]] auto get_pointer_tag() const noexcept -> pointer_tags
-    {
-      uint64_t tag;
-      std::memcpy(&tag, &m_tag, sizeof(tag));
-      return static_cast<pointer_tags>(
-        tag & static_cast<uint64_t>(pointer_tags::extract_mask));
-    }
-
-    /// set new pointer tag flag
-    void set_pointer_tag(pointer_tags tag) noexcept
-    {
-      // TODO: use std::declare_reachable for tagged pointer?
-      uint64_t tmp;
-      std::memcpy(&tmp, &m_tag, sizeof(tmp));
-      tmp &= static_cast<uint64_t>(pointer_tags::clear_mask);
-      tmp |= static_cast<uint64_t>(tag);
-      std::memcpy(&m_tag, &tmp, sizeof(m_tag));
-    }
-
-    void clear_pointer_tag() noexcept
-    {
-      uint64_t tmp;
-      std::memcpy(&tmp, &m_tag, sizeof(tmp));
-      tmp &= static_cast<uint64_t>(pointer_tags::clear_mask);
-      std::memcpy(&m_tag, &tmp, sizeof(m_tag));
-    }
-
     /// get pointer
     /// Ideally, optimized into single AND instruction.
     [[nodiscard]] auto get() const noexcept -> const Object*
     {
-      // load as non-pointer
-      uint64_t tag;
-      std::memcpy(&tag, &m_tag, sizeof(tag));
-      // clear pointer tag
-      tag &= static_cast<uint64_t>(pointer_tags::clear_mask);
-      // cast to pointer
-      const Object* ptr;
-      std::memcpy(&ptr, &tag, sizeof(ptr));
-      return ptr;
+      return m_ptr;
     }
 
     /// get address of header
@@ -89,13 +35,25 @@ namespace yave {
     [[nodiscard]] auto info_table() const noexcept -> const object_info_table*
     {
       assert(get());
-      return head()->info_table;
+      return detail::clear_info_table_tag(head()->info_table);
     }
 
-    /// exception? (optional)
+    /// exception?
     [[nodiscard]] bool is_exception() const noexcept
     {
-      return get_pointer_tag() == pointer_tags::exception;
+      return detail::has_exception_tag(head()->info_table);
+    }
+
+    /// apply?
+    [[nodiscard]] bool is_apply() const noexcept
+    {
+      return detail::has_apply_tag(head()->info_table);
+    }
+
+    /// function?
+    [[nodiscard]] bool is_function()
+    {
+      return detail::has_function_tag(head()->info_table);
     }
 
     /// static?
@@ -137,13 +95,8 @@ namespace yave {
     }
 
   private:
-    union
-    {
-      /// pointer to object
-      const Object* m_ptr;
-      /// pointer tag
-      uint64_t m_tag;
-    };
+    /// pointer to object
+    const Object* m_ptr;
   };
 
   // should be standard layout

--- a/include/yave/rts/object_ptr_storage.hpp
+++ b/include/yave/rts/object_ptr_storage.hpp
@@ -50,12 +50,6 @@ namespace yave {
       return detail::has_apply_tag(head()->info_table);
     }
 
-    /// function?
-    [[nodiscard]] bool is_function()
-    {
-      return detail::has_function_tag(head()->info_table);
-    }
-
     /// static?
     [[nodiscard]] bool is_static() const noexcept
     {

--- a/include/yave/rts/value_cast.hpp
+++ b/include/yave/rts/value_cast.hpp
@@ -22,7 +22,13 @@ namespace yave {
   [[nodiscard]] auto value_cast(const object_ptr<U>& obj)
     -> object_ptr<propagate_const_t<T, U>>
   {
-    if (likely(obj && has_type<T>(obj))) {
+    // Apply
+    if constexpr (std::is_same_v<std::decay_t<T>, Apply>) {
+      if (likely(obj && _get_storage(obj).is_apply()))
+        return static_object_cast<propagate_const_t<Apply, U>>(obj);
+    }
+    // general
+    else if (likely(obj && has_type<T>(obj))) {
       using To = typename decltype(
         get_object_type(normalize_specifier(type_c<T>)))::type;
       return static_object_cast<propagate_const_t<To, U>>(obj);
@@ -38,7 +44,13 @@ namespace yave {
   [[nodiscard]] auto value_cast(object_ptr<U>&& obj)
     -> object_ptr<propagate_const_t<T, U>>
   {
-    if (likely(obj && has_type<T>(obj))) {
+    // Apply
+    if constexpr (std::is_same_v<std::decay_t<T>, Apply>) {
+      if (likely(obj && _get_storage(obj).is_apply()))
+        return static_object_cast<propagate_const_t<Apply, U>>(std::move(obj));
+    }
+    // general
+    else if (likely(obj && has_type<T>(obj))) {
       using To = typename decltype(
         get_object_type(normalize_specifier(type_c<T>)))::type;
       return static_object_cast<propagate_const_t<To, U>>(std::move(obj));
@@ -54,7 +66,13 @@ namespace yave {
   [[nodiscard]] auto value_cast_if(const object_ptr<U>& obj) noexcept
     -> object_ptr<propagate_const_t<T, U>>
   {
-    if (likely(obj && has_type<T>(obj))) {
+    // Apply
+    if constexpr (std::is_same_v<std::decay_t<T>, Apply>) {
+      if (likely(obj && _get_storage(obj).is_apply()))
+        return static_object_cast<propagate_const_t<Apply, U>>(obj);
+    }
+    // general
+    else if (likely(obj && has_type<T>(obj))) {
       using To = typename decltype(
         get_object_type(normalize_specifier(type_c<T>)))::type;
       return static_object_cast<propagate_const_t<To, U>>(obj);
@@ -70,7 +88,13 @@ namespace yave {
   [[nodiscard]] auto value_cast_if(object_ptr<U>&& obj) noexcept
     -> object_ptr<propagate_const_t<T, U>>
   {
-    if (likely(obj && has_type<T>(obj))) {
+    // Apply
+    if constexpr (std::is_same_v<std::decay_t<T>, Apply>) {
+      if (likely(obj && _get_storage(obj).is_apply()))
+        return static_object_cast<propagate_const_t<Apply, U>>(std::move(obj));
+    }
+    // general
+    else if (likely(obj && has_type<T>(obj))) {
       using To = typename decltype(
         get_object_type(normalize_specifier(type_c<T>)))::type;
       return static_object_cast<propagate_const_t<To, U>>(std::move(obj));

--- a/include/yave/rts/value_cast.hpp
+++ b/include/yave/rts/value_cast.hpp
@@ -27,6 +27,11 @@ namespace yave {
       if (likely(obj && _get_storage(obj).is_apply()))
         return static_object_cast<propagate_const_t<Apply, U>>(obj);
     }
+    // Exception
+    else if constexpr (std::is_same_v<std::decay_t<T>, Exception>) {
+      if (likely(obj && _get_storage(obj).is_exception()))
+        return static_object_cast<propagate_const_t<Exception, U>>(obj);
+    }
     // general
     else if (likely(obj && has_type<T>(obj))) {
       using To = typename decltype(
@@ -48,6 +53,12 @@ namespace yave {
     if constexpr (std::is_same_v<std::decay_t<T>, Apply>) {
       if (likely(obj && _get_storage(obj).is_apply()))
         return static_object_cast<propagate_const_t<Apply, U>>(std::move(obj));
+    }
+    // Exception
+    else if constexpr (std::is_same_v<std::decay_t<T>, Exception>) {
+      if (likely(obj && _get_storage(obj).is_exception()))
+        return static_object_cast<propagate_const_t<Exception, U>>(
+          std::move(obj));
     }
     // general
     else if (likely(obj && has_type<T>(obj))) {
@@ -71,6 +82,11 @@ namespace yave {
       if (likely(obj && _get_storage(obj).is_apply()))
         return static_object_cast<propagate_const_t<Apply, U>>(obj);
     }
+    // Exception
+    else if constexpr (std::is_same_v<std::decay_t<T>, Exception>) {
+      if (likely(obj && _get_storage(obj).is_exception()))
+        return static_object_cast<propagate_const_t<Exception, U>>(obj);
+    }
     // general
     else if (likely(obj && has_type<T>(obj))) {
       using To = typename decltype(
@@ -92,6 +108,12 @@ namespace yave {
     if constexpr (std::is_same_v<std::decay_t<T>, Apply>) {
       if (likely(obj && _get_storage(obj).is_apply()))
         return static_object_cast<propagate_const_t<Apply, U>>(std::move(obj));
+    }
+    // Exception
+    else if constexpr (std::is_same_v<std::decay_t<T>, Exception>) {
+      if (likely(obj && _get_storage(obj).is_exception()))
+        return static_object_cast<propagate_const_t<Exception, U>>(
+          std::move(obj));
     }
     // general
     else if (likely(obj && has_type<T>(obj))) {


### PR DESCRIPTION
Current object pointer tagging is not very useful except for small special cases.  
This PR replaces current object pointer tagging to info table pointer tagging.  
This might degrade small performance for codes currently using object pointer tags, but brings more possibilities to optimize dynamic casting and run time type check.
