### PR TITLE
Make buffers deep copy by default.

### DIFF
--- a/include/yave/backend/default/render/blend_op.hpp
+++ b/include/yave/backend/default/render/blend_op.hpp
@@ -43,7 +43,7 @@ namespace yave {
         auto fb_dst = eval_arg<1>();
 
         // clone dst
-        auto dst = fb_dst->copy();
+        auto dst = clone(fb_dst);
 
         const_image_view src_view   = fb_src->get_image_view();
         mutable_image_view dst_view = dst->get_image_view();
@@ -76,7 +76,7 @@ namespace yave {
         auto fb_dst = eval_arg<1>();
 
         // clone dst
-        auto dst = fb_dst->copy();
+        auto dst = clone(fb_dst);
 
         const_image_view src_view   = fb_src->get_image_view();
         mutable_image_view dst_view = dst->get_image_view();
@@ -109,7 +109,7 @@ namespace yave {
         auto fb_dst = eval_arg<1>();
 
         // clone dst
-        auto dst = fb_dst->copy();
+        auto dst = clone(fb_dst);
 
         const_image_view src_view   = fb_src->get_image_view();
         mutable_image_view dst_view = dst->get_image_view();
@@ -142,7 +142,7 @@ namespace yave {
         auto fb_dst = eval_arg<1>();
 
         // clone dst
-        auto dst = fb_dst->copy();
+        auto dst = clone(fb_dst);
 
         const_image_view src_view   = fb_src->get_image_view();
         mutable_image_view dst_view = dst->get_image_view();

--- a/include/yave/lib/frame_buffer/frame_buffer.hpp
+++ b/include/yave/lib/frame_buffer/frame_buffer.hpp
@@ -16,27 +16,13 @@ namespace yave {
   /// Frame buffer object value.
   struct frame_buffer : buffer_base<frame_buffer, FrameBufferPool>
   {
-    frame_buffer(const object_ptr<FrameBufferPool>& pool)
-      : buffer_base(pool)
-    {
-      m_id = pool->create();
-
-      if (m_id == uid())
-        throw std::bad_alloc();
-    }
-
-    frame_buffer(const object_ptr<FrameBufferPool>& pool, uid id)
-      : buffer_base(pool)
-    {
-      m_id = pool->create_from(id);
-
-      if (m_id == uid())
-        throw std::bad_alloc();
-    }
+    /// Create new frame buffer
+    frame_buffer(const object_ptr<FrameBufferPool>& pool);
 
     /// Get image view.
-    [[nodiscard]] mutable_image_view get_image_view();
+    [[nodiscard]] auto get_image_view() -> mutable_image_view;
+
     /// Get image view.
-    [[nodiscard]] const_image_view get_image_view() const;
+    [[nodiscard]] auto get_image_view() const -> const_image_view;
   };
 }

--- a/src/yave/lib/frame_buffer/frame_buffer.cpp
+++ b/src/yave/lib/frame_buffer/frame_buffer.cpp
@@ -8,6 +8,13 @@
 
 namespace yave {
 
+  frame_buffer::frame_buffer(const object_ptr<FrameBufferPool>& pool)
+    : buffer_base(pool, pool->create())
+  {
+    if (m_id == uid())
+      throw std::bad_alloc();
+  }
+
   mutable_image_view frame_buffer::get_image_view()
   {
     return mutable_image_view(

--- a/test/lib/frame_buffer/frame_buffer.cpp
+++ b/test/lib/frame_buffer/frame_buffer.cpp
@@ -8,6 +8,8 @@
 #include <yave/lib/frame_buffer/frame_buffer_manager.hpp>
 #include <yave/lib/frame_buffer/frame_buffer.hpp>
 
+#include <yave/rts/utility.hpp>
+
 using namespace yave;
 
 TEST_CASE("", "[lib][frame_buffer]")
@@ -51,6 +53,11 @@ TEST_CASE("3", "[lib][frame_buffer]")
   REQUIRE(view.image_format() == mngr.format());
   REQUIRE(view.width() == 1920);
   REQUIRE(view.height() == 1080);
-  auto f2                        = f1->copy();
+
+  auto f2 = clone(f1);
+  REQUIRE(f2->id() != f1->id());
+
   f2->get_image_view().data()[0] = 255;
+  REQUIRE(f2->get_image_view().data()[0] == 255);
+  REQUIRE(f1->get_image_view().data()[0] != 255);
 }


### PR DESCRIPTION
Remove copy() since clone() can be used.