### PR TITLE
node_compiler support for V2 node graph

### DIFF
--- a/include/yave/node/compiler/node_compiler.hpp
+++ b/include/yave/node/compiler/node_compiler.hpp
@@ -20,6 +20,8 @@ namespace yave {
   public:
     /// Ctor
     node_compiler();
+    /// Dtor
+    ~node_compiler() noexcept;
 
     /// Compile parsed graph
     [[nodiscard]] auto compile(
@@ -30,27 +32,8 @@ namespace yave {
     [[nodiscard]] auto get_errors() const -> error_list;
 
   private:
-    /// Optimize parsed graph
-    [[nodiscard]] auto _optimize_early(managed_node_graph&& graph)
-      -> std::optional<managed_node_graph>;
-
-    /// Resolve overloadings and check type
-    [[nodiscard]] auto _type(
-      const managed_node_graph& graph,
-      const node_definition_store& defs) -> std::optional<executable>;
-
-    /// Verbose type check
-    [[nodiscard]] auto _verbose_check(
-      const executable& executable,
-      const managed_node_graph& graph) -> bool;
-
-    /// Optimize executable
-    [[nodiscard]] auto _optimize(
-      executable&& exe,
-      const managed_node_graph& graph) -> executable;
-
-  private:
-    error_list m_errors;
+    class impl;
+    std::unique_ptr<impl> m_pimpl;
   };
 
 } // namespace yave

--- a/include/yave/node/compiler/node_compiler.hpp
+++ b/include/yave/node/compiler/node_compiler.hpp
@@ -28,6 +28,11 @@ namespace yave {
       managed_node_graph&& graph,
       const node_definition_store& defs) -> std::optional<executable>;
 
+    /// Compile parsed V2 node graph
+    [[nodiscard]] auto compile(
+      structured_node_graph&& graph,
+      const node_definition_store& defs) -> std::optional<executable>;
+
     /// Get last errors
     [[nodiscard]] auto get_errors() const -> error_list;
 

--- a/src/yave/node/compiler/CMakeLists.txt
+++ b/src/yave/node/compiler/CMakeLists.txt
@@ -10,6 +10,8 @@ add_library(yave::node::compiler ALIAS yave-node-compiler)
 
 target_link_libraries(yave-node-compiler PUBLIC yave::config)
 target_link_libraries(yave-node-compiler PUBLIC yave::node::core)
+target_link_libraries(yave-node-compiler PRIVATE yave::node::parser)
 target_link_libraries(yave-node-compiler PRIVATE yave::support::log)
 target_link_libraries(yave-node-compiler PRIVATE yave::support::error)
 target_link_libraries(yave-node-compiler PRIVATE yave::module::std)
+target_link_libraries(yave-node-compiler PRIVATE tl::optional)

--- a/src/yave/node/compiler/node_compiler.cpp
+++ b/src/yave/node/compiler/node_compiler.cpp
@@ -604,8 +604,7 @@ namespace yave {
           if (cs.empty())
             return body;
 
-          auto c  = ng.connections(s)[0];
-          auto ci = ng.get_info(c);
+          auto ci = ng.get_info(cs[0]);
           body =
             body << rec_n(ci->src_node(), ci->src_socket(), in, defs, ng, env);
         }

--- a/src/yave/node/compiler/node_compiler.cpp
+++ b/src/yave/node/compiler/node_compiler.cpp
@@ -26,6 +26,7 @@ YAVE_DECL_G_LOGGER(node_compiler)
 using namespace std::string_literals;
 
 // MACROS ARE (NOT) YOUR FRIEND.
+#pragma GCC diagnostic ignored "-Wgnu-zero-variadic-macro-arguments"
 #define VA_mem_fn(...) , ##__VA_ARGS__
 #define mem_fn(FN, ...)                                                 \
   [&](auto&& arg) {                                                     \

--- a/src/yave/node/core/node_graph.cpp
+++ b/src/yave/node/core/node_graph.cpp
@@ -630,6 +630,10 @@ namespace yave {
         Info(
           g_logger, "Enable custom data on socket: id={}", to_string(h.id()));
 
+      if (!data)
+        Info(
+          g_logger, "Clearing custom data on socket: id={}", to_string(h.id()));
+
       g[h.descriptor()].set_data(std::move(data));
     }
 
@@ -637,6 +641,10 @@ namespace yave {
     {
       if (!g[h.descriptor()].has_data())
         Info(g_logger, "Enable custom data on node: id={}", to_string(h.id()));
+
+      if (!data)
+        Info(
+          g_logger, "Clearing custom data on socket: id={}", to_string(h.id()));
 
       g[h.descriptor()].set_data(std::move(data));
     }
@@ -1147,18 +1155,12 @@ namespace yave {
     if (!exists(h))
       return;
 
-    if (!data)
-      return;
-
     return m_pimpl->set_data(h, data);
   }
 
   void node_graph::set_data(const node_handle& h, object_ptr<Object> data)
   {
     if (!exists(h))
-      return;
-
-    if (!data)
       return;
 
     return m_pimpl->set_data(h, data);

--- a/test/node/compiler/compiler.cpp
+++ b/test/node/compiler/compiler.cpp
@@ -34,11 +34,11 @@ struct AddI : NodeFunction<AddI, Int, Int, Int>
   }
 };
 
-struct AddD : NodeFunction<AddD, Double, Double, Double>
+struct AddF : NodeFunction<AddF, Float, Float, Float>
 {
   return_type code() const
   {
-    return make_object<Double>(*eval_arg<0>() + *eval_arg<1>());
+    return make_object<Float>(*eval_arg<0>() + *eval_arg<1>());
   }
 };
 
@@ -48,7 +48,7 @@ struct yave::node_declaration_traits<n::Add>
   static auto get_node_declaration()
   {
     class X;
-    return node_declaration("add", "", "", {"x", "y"}, {"out"});
+    return node_declaration("add", "/test", "", {"x", "y"}, {"out"});
   }
 };
 
@@ -59,21 +59,381 @@ struct yave::node_definition_traits<n::Add, test_backend>
   {
     // Int version
     auto defi = node_definition(
-      get_node_declaration<n::Add>().name(),
-      0,
-      make_object<AddI>(),
-      "AddI");
+      get_node_declaration<n::Add>().name(), 0, make_object<AddI>(), "AddI");
 
-    // Double version
+    // Float version
     auto defd = node_definition(
-      get_node_declaration<n::Add>().name(),
-      0,
-      make_object<AddD>(),
-      "AddD");
+      get_node_declaration<n::Add>().name(), 0, make_object<AddF>(), "AddF");
 
     return {defi, defd};
   }
 };
+
+TEST_CASE("node_compiler V2")
+{
+  structured_node_graph ng;
+  node_parser parser;
+  node_compiler compiler;
+  node_definition_store defs;
+
+  // clang-format off
+
+  auto int_decl   = get_node_declaration<node::Int>();
+  auto bool_decl  = get_node_declaration<node::Bool>();
+  auto float_decl = get_node_declaration<node::Float>();
+  auto if_decl    = get_node_declaration<node::If>();
+  auto nil_decl   = get_node_declaration<node::ListNil>();
+  auto cons_decl  = get_node_declaration<node::ListCons>();
+  auto add_decl   = get_node_declaration<n::Add>();
+
+  auto add_defs   = get_node_definitions<n::Add, test_backend>();
+  auto int_defs   = get_node_definitions<node::Int, modules::_std::tag>();
+  auto bool_defs  = get_node_definitions<node::Bool, modules::_std::tag>();
+  auto float_defs = get_node_definitions<node::Float, modules::_std::tag>();
+  auto if_defs    = get_node_definitions<node::If, modules::_std::tag>();
+  auto nil_defs   = get_node_definitions<node::ListNil, modules::_std::tag>();
+  auto cons_defs  = get_node_definitions<node::ListCons, modules::_std::tag>();
+
+  // clang-format on
+
+  defs.add(add_defs);
+  defs.add(int_defs);
+  defs.add(float_defs);
+  defs.add(bool_defs);
+  defs.add(if_defs);
+  defs.add(nil_defs);
+  defs.add(cons_defs);
+
+  auto int_func   = ng.create_function(int_decl);
+  auto add_func   = ng.create_function(add_decl);
+  auto float_func = ng.create_function(float_decl);
+  auto bool_func  = ng.create_function(bool_decl);
+  auto if_func    = ng.create_function(if_decl);
+  auto nil_func   = ng.create_function(nil_decl);
+  auto cons_func  = ng.create_function(cons_decl);
+
+  REQUIRE(int_func);
+  REQUIRE(add_func);
+  REQUIRE(float_func);
+  REQUIRE(bool_func);
+  REQUIRE(if_func);
+  REQUIRE(nil_func);
+  REQUIRE(cons_func);
+
+  auto root = ng.create_group(nullptr);
+  ng.set_name(root, "root");
+  REQUIRE(ng.add_output_socket(root, "out"));
+
+  auto os = ng.input_sockets(ng.get_group_output(root))[0];
+
+  SECTION("int")
+  {
+    auto n = ng.create_copy(root, int_func);
+    REQUIRE(ng.connect(ng.output_sockets(n)[0], os));
+    REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("int float")
+  {
+    auto i = ng.create_copy(root, int_func);
+    auto f = ng.create_copy(root, float_func);
+    REQUIRE(i);
+    REQUIRE(f);
+    REQUIRE(ng.connect(ng.output_sockets(i)[0], os));
+    REQUIRE(ng.connect(ng.output_sockets(f)[0], ng.input_sockets(i)[0]));
+    // missmatch
+    REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("add")
+  {
+    auto add = ng.create_copy(root, add_func);
+    REQUIRE(add);
+    REQUIRE(ng.connect(ng.output_sockets(add)[0], os));
+    // ambiguous
+    REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("add int int")
+  {
+    auto add = ng.create_copy(root, add_func);
+    auto i1  = ng.create_copy(root, int_func);
+    auto i2  = ng.create_copy(root, int_func);
+
+    REQUIRE(add);
+    REQUIRE(i1);
+    REQUIRE(i2);
+
+    REQUIRE(ng.connect(ng.output_sockets(add)[0], os));
+    REQUIRE(ng.connect(ng.output_sockets(i1)[0], ng.input_sockets(add)[0]));
+    REQUIRE(ng.connect(ng.output_sockets(i2)[0], ng.input_sockets(add)[1]));
+    REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("add float float")
+  {
+    auto add = ng.create_copy(root, add_func);
+    auto f1  = ng.create_copy(root, float_func);
+    auto f2  = ng.create_copy(root, float_func);
+
+    REQUIRE(add);
+    REQUIRE(f1);
+    REQUIRE(f2);
+
+    REQUIRE(ng.connect(ng.output_sockets(add)[0], os));
+    REQUIRE(ng.connect(ng.output_sockets(f1)[0], ng.input_sockets(add)[0]));
+    REQUIRE(ng.connect(ng.output_sockets(f2)[0], ng.input_sockets(add)[1]));
+    REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("add int float")
+  {
+    auto add = ng.create_copy(root, add_func);
+    auto i   = ng.create_copy(root, int_func);
+    auto f   = ng.create_copy(root, float_func);
+
+    REQUIRE(add);
+    REQUIRE(i);
+    REQUIRE(f);
+
+    REQUIRE(ng.connect(ng.output_sockets(add)[0], os));
+    REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(add)[0]));
+    REQUIRE(ng.connect(ng.output_sockets(f)[0], ng.input_sockets(add)[1]));
+    // missmatch
+    REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("add (add int int) int")
+  {
+    auto add1 = ng.create_copy(root, add_func);
+    auto add2 = ng.create_copy(root, add_func);
+    auto i    = ng.create_copy(root, int_func);
+
+    REQUIRE(add1);
+    REQUIRE(add2);
+    REQUIRE(i);
+
+    auto add1_x   = ng.input_sockets(add1)[0];
+    auto add1_y   = ng.input_sockets(add1)[1];
+    auto add1_out = ng.output_sockets(add1)[0];
+    auto add2_x   = ng.input_sockets(add2)[0];
+    auto add2_y   = ng.input_sockets(add2)[1];
+    auto add2_out = ng.output_sockets(add2)[0];
+    auto i_value  = ng.output_sockets(i)[0];
+
+    REQUIRE(ng.connect(add1_out, os));
+
+    REQUIRE(ng.connect(add2_out, add1_x));
+    REQUIRE(ng.connect(i_value, add1_y));
+    REQUIRE(ng.connect(i_value, add2_x));
+    REQUIRE(ng.connect(i_value, add2_y));
+
+    REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("add (add int float) int")
+  {
+    auto add1 = ng.create_copy(root, add_func);
+    auto add2 = ng.create_copy(root, add_func);
+    auto i    = ng.create_copy(root, int_func);
+    auto d    = ng.create_copy(root, float_func);
+
+    REQUIRE(add1);
+    REQUIRE(add2);
+    REQUIRE(i);
+    REQUIRE(d);
+
+    auto add1_out = ng.output_sockets(add1)[0];
+    auto add2_out = ng.output_sockets(add2)[0];
+    auto i_value  = ng.output_sockets(i)[0];
+    auto d_value  = ng.output_sockets(d)[0];
+    auto add1_x   = ng.input_sockets(add1)[0];
+    auto add1_y   = ng.input_sockets(add1)[1];
+    auto add2_x   = ng.input_sockets(add2)[0];
+    auto add2_y   = ng.input_sockets(add2)[1];
+
+    REQUIRE(ng.connect(add1_out, os));
+    REQUIRE(ng.connect(add2_out, add1_x));
+    REQUIRE(ng.connect(i_value, add1_y));
+    REQUIRE(ng.connect(i_value, add2_x));
+    REQUIRE(ng.connect(d_value, add2_y));
+
+    REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("if bool int int")
+  {
+    auto _if = ng.create_copy(root, if_func);
+    auto i   = ng.create_copy(root, int_func);
+    auto b   = ng.create_copy(root, bool_func);
+
+    REQUIRE(_if);
+    REQUIRE(i);
+    REQUIRE(b);
+
+    auto b_value  = ng.output_sockets(b)[0];
+    auto i_value  = ng.output_sockets(i)[0];
+    auto _if_cond = ng.input_sockets(_if)[0];
+    auto _if_then = ng.input_sockets(_if)[1];
+    auto _if_else = ng.input_sockets(_if)[2];
+    auto _if_out  = ng.output_sockets(_if)[0];
+
+    REQUIRE(ng.connect(_if_out, os));
+    REQUIRE(ng.connect(b_value, _if_cond));
+    REQUIRE(ng.connect(i_value, _if_then));
+    REQUIRE(ng.connect(i_value, _if_else));
+
+    REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+  }
+
+  SECTION("if bool (if bool int int) int")
+  {
+    auto if1 = ng.create_copy(root, if_func);
+    auto if2 = ng.create_copy(root, if_func);
+    auto i   = ng.create_copy(root, int_func);
+    auto b   = ng.create_copy(root, bool_func);
+
+    REQUIRE(if1);
+    REQUIRE(if2);
+    REQUIRE(i);
+    REQUIRE(b);
+
+    auto b_value = ng.output_sockets(b)[0];
+    auto i_value = ng.output_sockets(i)[0];
+
+    auto if1_cond = ng.input_sockets(if1)[0];
+    auto if1_then = ng.input_sockets(if1)[1];
+    auto if1_else = ng.input_sockets(if1)[2];
+    auto if1_out  = ng.output_sockets(if1)[0];
+
+    auto if2_cond = ng.input_sockets(if2)[0];
+    auto if2_then = ng.input_sockets(if2)[1];
+    auto if2_else = ng.input_sockets(if2)[2];
+    auto if2_out  = ng.output_sockets(if2)[0];
+
+    REQUIRE(ng.connect(if1_out, os));
+    REQUIRE(ng.connect(b_value, if1_cond));
+    REQUIRE(ng.connect(if2_out, if1_then));
+    REQUIRE(ng.connect(b_value, if2_cond));
+    REQUIRE(ng.connect(i_value, if2_then));
+    REQUIRE(ng.connect(i_value, if2_else));
+    REQUIRE(ng.connect(i_value, if1_else));
+
+    REQUIRE(compiler.compile(parser.parse(std::move(ng)).value(), defs));
+  }
+
+  SECTION("if bool int float")
+  {
+    auto _if = ng.create_copy(root, if_func);
+    auto i   = ng.create_copy(root, int_func);
+    auto d   = ng.create_copy(root, float_func);
+    auto b   = ng.create_copy(root, bool_func);
+
+    REQUIRE(_if);
+    REQUIRE(i);
+    REQUIRE(d);
+    REQUIRE(b);
+
+    auto i_value  = ng.output_sockets(i)[0];
+    auto d_value  = ng.output_sockets(d)[0];
+    auto b_value  = ng.output_sockets(b)[0];
+    auto _if_cond = ng.input_sockets(_if)[0];
+    auto _if_then = ng.input_sockets(_if)[1];
+    auto _if_else = ng.input_sockets(_if)[2];
+    auto _if_out  = ng.output_sockets(_if)[0];
+
+    REQUIRE(ng.connect(_if_out, os));
+    REQUIRE(ng.connect(b_value, _if_cond));
+    REQUIRE(ng.connect(i_value, _if_then));
+    REQUIRE(ng.connect(d_value, _if_else));
+
+    REQUIRE(!compiler.compile(parser.parse(std::move(ng)).value(), defs));
+  }
+
+  SECTION("42 : []")
+  {
+    auto i    = ng.create_copy(root, int_func);
+    auto nil  = ng.create_copy(root, nil_func);
+    auto cons = ng.create_copy(root, cons_func);
+
+    REQUIRE(i);
+    REQUIRE(nil);
+    REQUIRE(cons);
+
+    auto i_value   = ng.output_sockets(i)[0];
+    auto nil_value = ng.output_sockets(nil)[0];
+    auto cons_head = ng.input_sockets(cons)[0];
+    auto cons_tail = ng.input_sockets(cons)[1];
+    auto cons_out  = ng.output_sockets(cons)[0];
+
+    REQUIRE(ng.connect(cons_out, os));
+    REQUIRE(ng.connect(i_value, cons_head));
+    REQUIRE(ng.connect(nil_value, cons_tail));
+
+    REQUIRE(compiler.compile(std::move(ng), defs));
+  }
+
+  SECTION("f = [x y -> x + y]")
+  {
+    auto f = ng.create_group(root);
+    ng.set_name(f, "/x y -> x + y");
+    auto a = ng.create_copy(f, add_func);
+    REQUIRE(ng.add_output_socket(f, "out"));
+    REQUIRE(ng.add_input_socket(f, "x"));
+    REQUIRE(ng.add_input_socket(f, "y"));
+
+    REQUIRE(ng.connect(
+      ng.output_sockets(a)[0], ng.input_sockets(ng.get_group_output(f))[0]));
+    REQUIRE(ng.connect(
+      ng.output_sockets(ng.get_group_input(f))[0], ng.input_sockets(a)[0]));
+    REQUIRE(ng.connect(
+      ng.output_sockets(ng.get_group_input(f))[1], ng.input_sockets(a)[1]));
+
+    REQUIRE(ng.connect(ng.output_sockets(f)[0], os));
+
+    SECTION("f")
+    {
+      REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+    }
+
+    SECTION("f int int")
+    {
+      auto i = ng.create_copy(root, int_func);
+      REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(f)[0]));
+      REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(f)[1]));
+      REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+    }
+
+    SECTION("f int int")
+    {
+      auto i = ng.create_copy(root, float_func);
+      REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(f)[0]));
+      REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(f)[1]));
+      REQUIRE(compiler.compile(parser.parse(ng.clone()).value(), defs));
+    }
+
+    SECTION("f int float")
+    {
+      auto i = ng.create_copy(root, int_func);
+      auto j = ng.create_copy(root, float_func);
+      REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(f)[0]));
+      REQUIRE(ng.connect(ng.output_sockets(j)[0], ng.input_sockets(f)[1]));
+      REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+    }
+
+    SECTION("f int (f2 float float)")
+    {
+      auto f2 = ng.create_copy(root, f);
+      auto i = ng.create_copy(root, int_func);
+      auto j = ng.create_copy(root, float_func);
+      REQUIRE(ng.connect(ng.output_sockets(i)[0], ng.input_sockets(f)[0]));
+      REQUIRE(ng.connect(ng.output_sockets(f2)[0], ng.input_sockets(f)[1]));
+      REQUIRE(ng.connect(ng.output_sockets(j)[0], ng.input_sockets(f2)[0]));
+      REQUIRE(ng.connect(ng.output_sockets(j)[0], ng.input_sockets(f2)[1]));
+      REQUIRE(!compiler.compile(parser.parse(ng.clone()).value(), defs));
+    }
+  }
+}
 
 TEST_CASE("add", "[node_compiler]")
 {
@@ -82,23 +442,23 @@ TEST_CASE("add", "[node_compiler]")
   node_declaration_store decls;
   node_definition_store defs;
 
-  // clang-format off 
+  // clang-format off
 
-  auto int_decl    = get_node_declaration<node::Int>();
-  auto bool_decl   = get_node_declaration<node::Bool>();
-  auto float_decl  = get_node_declaration<node::Float>();
-  auto if_decl     = get_node_declaration<node::If>();
-  auto nil_decl    = get_node_declaration<node::ListNil>();
-  auto cons_decl   = get_node_declaration<node::ListCons>();
-  auto add_decl    = get_node_declaration<n::Add>();
+  auto int_decl   = get_node_declaration<node::Int>();
+  auto bool_decl  = get_node_declaration<node::Bool>();
+  auto float_decl = get_node_declaration<node::Float>();
+  auto if_decl    = get_node_declaration<node::If>();
+  auto nil_decl   = get_node_declaration<node::ListNil>();
+  auto cons_decl  = get_node_declaration<node::ListCons>();
+  auto add_decl   = get_node_declaration<n::Add>();
 
-  auto add_defs    = get_node_definitions<n::Add, test_backend>();
-  auto int_defs    = get_node_definitions<node::Int, modules::_std::tag>();
-  auto bool_defs   = get_node_definitions<node::Bool, modules::_std::tag>();
-  auto float_defs  = get_node_definitions<node::String, modules::_std::tag>();
-  auto if_defs     = get_node_definitions<node::If, modules::_std::tag>();
-  auto nil_defs    = get_node_definitions<node::ListNil, modules::_std::tag>();
-  auto cons_defs   = get_node_definitions<node::ListCons, modules::_std::tag>();
+  auto add_defs   = get_node_definitions<n::Add, test_backend>();
+  auto int_defs   = get_node_definitions<node::Int, modules::_std::tag>();
+  auto bool_defs  = get_node_definitions<node::Bool, modules::_std::tag>();
+  auto float_defs = get_node_definitions<node::Float, modules::_std::tag>();
+  auto if_defs    = get_node_definitions<node::If, modules::_std::tag>();
+  auto nil_defs   = get_node_definitions<node::ListNil, modules::_std::tag>();
+  auto cons_defs  = get_node_definitions<node::ListCons, modules::_std::tag>();
 
   // clang-format on
 
@@ -329,7 +689,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(d_value, _if_else));
 
     REQUIRE(!compiler.compile(std::move(graph), defs));
-}
+  }
 
   SECTION("add<int> x y")
   {


### PR DESCRIPTION
This PR implements `node_compiler` for `structured_node_graph`

- [x] Desugar stage
  - Add variable for lambda forms (maybe merge into Gen stage?)
- [x] Gen stage
  - Generate RTS graph with overloaded nodes
  - Expand AST at this point
- [x] Type stage
  - Resolve overloadings
- [ ] Optimize stage
  - Fold apply graph
- [ ] Verbose check and tests
  - Check type with RTS's `type_of()`
