### PR TITLE
Use qualified name to lookup node definitions

### DIFF
--- a/include/yave/app/node_compiler_thread.hpp
+++ b/include/yave/app/node_compiler_thread.hpp
@@ -54,6 +54,7 @@ namespace yave::app {
     /// Queue compilation
     void compile(
       const std::shared_ptr<const node_data_snapshot>& snapshot,
+      const node_declaration_store& decls,
       const node_definition_store& defs);
 
     /// Get last executable

--- a/include/yave/config/config.hpp
+++ b/include/yave/config/config.hpp
@@ -13,6 +13,7 @@
 #include <yave/config/os.hpp>
 #include <yave/config/compiler.hpp>
 #include <yave/config/uuid.hpp>
+#include <yave/config/fix.hpp>
 
 #include <cstdint>
 #include <cstddef>

--- a/include/yave/config/fix.hpp
+++ b/include/yave/config/fix.hpp
@@ -1,0 +1,35 @@
+//
+// Copyright (c) 2019 mocabe (https://github.com/mocabe)
+// Distributed under LGPLv3 License. See LICENSE for more details.
+//
+
+#pragma once
+
+namespace yave {
+
+  /// helper class to fix lambda
+  template <class F>
+  struct fix_lambda : private F
+  {
+    template <class G>
+    constexpr fix_lambda(G&& g)
+      : F {std::forward<G>(g)}
+    {
+    }
+
+    template <typename... Args>
+    constexpr decltype(auto) operator()(Args&&... args) const
+    {
+      return F::operator()(*this, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    constexpr decltype(auto) operator()(Args&&... args)
+    {
+      return F::operator()(*this, std::forward<Args>(args)...);
+    }
+  };
+
+  template <class F>
+  fix_lambda(F &&)->fix_lambda<std::decay_t<F>>;
+}

--- a/include/yave/module/ext/external_module_node_definition.hpp
+++ b/include/yave/module/ext/external_module_node_definition.hpp
@@ -20,16 +20,16 @@ namespace yave {
   {
     external_module_node_definition(const node_definition& def)
     {
-      m_name        = def.name();
-      m_instance    = def.instance();
-      m_output      = def.output_socket();
-      m_description = def.description();
+      m_qualified_name = def.qualified_name();
+      m_instance       = def.instance();
+      m_output         = def.output_socket();
+      m_description    = def.description();
     }
 
     /// Get name
-    [[nodiscard]] auto name() const -> std::string
+    [[nodiscard]] auto qualified_name() const -> std::string
     {
-      return m_name;
+      return m_qualified_name;
     }
 
     /// Get output socket index
@@ -53,11 +53,11 @@ namespace yave {
     /// Convert to yave::bind info
     [[nodiscard]] auto node_definition() const -> node_definition
     {
-      return {name(), output_socket(), instance(), description()};
+      return {qualified_name(), output_socket(), instance(), description()};
     }
 
   private:
-    string m_name;                       // 16
+    string m_qualified_name;             // 16
     string m_description;                // 16
     uint64_t m_output;                   // 8
     object_ptr<const Object> m_instance; // 8

--- a/include/yave/node/compiler/node_compiler.hpp
+++ b/include/yave/node/compiler/node_compiler.hpp
@@ -26,6 +26,7 @@ namespace yave {
     /// Compile parsed graph
     [[nodiscard]] auto compile(
       managed_node_graph&& graph,
+      const node_declaration_store& decls,
       const node_definition_store& defs) -> std::optional<executable>;
 
     /// Compile parsed V2 node graph

--- a/include/yave/node/compiler/type.hpp
+++ b/include/yave/node/compiler/type.hpp
@@ -25,14 +25,20 @@ namespace yave {
 
   class class_env
   {
-  private:
     std::map<object_ptr<const Type>, overloaded_class, var_type_comp> m_map;
 
   public:
+    /// register overloading info and returns new Overloaded object
     [[nodiscard]] auto add_overloading(
+      const uid& id,
       const std::vector<object_ptr<const Object>>& instances)
       -> object_ptr<const Overloaded>;
 
+    /// Finds registered overloading from ID and returns new Overloaded object
+    [[nodiscard]] auto find_overloaded(const uid& id) const
+      -> object_ptr<const Overloaded>;
+
+    /// Aquire overloading info from class ID
     [[nodiscard]] auto find_overloading(
       const object_ptr<const Type>& class_id) const -> const overloaded_class*;
   };

--- a/include/yave/node/core/node_definition.hpp
+++ b/include/yave/node/core/node_definition.hpp
@@ -16,17 +16,18 @@ namespace yave {
   {
   public:
     /// Construct node definition.
-    /// \param name name of bind (should match to target node_info::name())
+    /// \param qualified_name fully qualified name of bind (should match to
+    /// target node_info::qualified_name())
     /// \param output_socket name of output socket
     /// \param description Description of this bind.
     /// \param inst_getter A non-null managed pointer to a closure object
     /// \throws std::invalid_argument when arguments are invalid.
     node_definition(
-      std::string name,
+      std::string qualified_name,
       size_t output_socket,
       object_ptr<const Object> instance,
       std::string description)
-      : m_name {std::move(name)}
+      : m_qualified_name {std::move(qualified_name)}
       , m_os {std::move(output_socket)}
       , m_instance {std::move(instance)}
       , m_description {std::move(description)}
@@ -36,9 +37,9 @@ namespace yave {
         throw std::invalid_argument("instance is null");
     }
 
-    [[nodiscard]] auto& name() const
+    [[nodiscard]] auto& qualified_name() const
     {
-      return m_name;
+      return m_qualified_name;
     }
 
     [[nodiscard]] auto& description() const
@@ -58,7 +59,7 @@ namespace yave {
 
   private:
     /// name of name
-    std::string m_name;
+    std::string m_qualified_name;
     /// output socket index
     size_t m_os;
     /// instance getter

--- a/include/yave/node/core/node_definition_store.hpp
+++ b/include/yave/node/core/node_definition_store.hpp
@@ -39,24 +39,24 @@ namespace yave {
     /// Add definitions
     void add(const std::vector<node_definition>& defs);
     /// Remove definitions
-    void remove(const std::string& name);
+    void remove(const std::string& qualified_name);
     /// Remove definitions
-    void remove(const std::vector<std::string>& names);
+    void remove(const std::vector<std::string>& qualified_name);
 
     /// Exists?
-    [[nodiscard]] bool exists(const std::string& name) const;
+    [[nodiscard]] bool exists(const std::string& qualified_name) const;
     /// Exists?
     [[nodiscard]] bool exists(
-      const std::string& name,
+      const std::string& qualified_name,
       const size_t& output_socket) const;
 
     /// Find definition
-    [[nodiscard]] auto find(const std::string& name) const
+    [[nodiscard]] auto find(const std::string& qualified_name) const
       -> std::vector<std::shared_ptr<const node_definition>>;
 
     /// Get compatible binds
     [[nodiscard]] auto get_binds(
-      const std::string& name,
+      const std::string& qualified_name,
       const size_t& output_socket) const
       -> std::vector<std::shared_ptr<const node_definition>>;
 

--- a/src/yave/app/editor_context.cpp
+++ b/src/yave/app/editor_context.cpp
@@ -805,7 +805,8 @@ namespace yave::app {
   public:
     void compile()
     {
-      compiler_thread.compile(snapshot, project.node_definitions());
+      compiler_thread.compile(
+        snapshot, project.node_declarations(), project.node_definitions());
     }
 
     bool is_compiling() const

--- a/src/yave/module/std/color/color.cpp
+++ b/src/yave/module/std/color/color.cpp
@@ -42,7 +42,7 @@ namespace yave {
   {
     auto info = get_node_declaration<node::Color>();
     return std::vector {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::color::ColorCtor>(),
       info.description())};

--- a/src/yave/module/std/filesystem/path.cpp
+++ b/src/yave/module/std/filesystem/path.cpp
@@ -40,7 +40,7 @@ namespace yave {
   {
     auto info = get_node_declaration<node::FilePath>();
     return std::vector {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::filesystem::FilePathConstructor>(),
       info.description())};

--- a/src/yave/module/std/geometry/rect.cpp
+++ b/src/yave/module/std/geometry/rect.cpp
@@ -51,7 +51,7 @@ namespace yave {
     auto info = get_node_declaration<node::Rect2>();
 
     return std::vector {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Rect2Ctor>(),
       info.description())};
@@ -63,7 +63,7 @@ namespace yave {
     auto info = get_node_declaration<node::Rect3>();
 
     return std::vector {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Rect3Ctor>(),
       info.description())};

--- a/src/yave/module/std/geometry/vec.cpp
+++ b/src/yave/module/std/geometry/vec.cpp
@@ -89,7 +89,7 @@ namespace yave {
     auto info = get_node_declaration<node::Vec2>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Vec2Constructor>(),
       info.description())};
@@ -101,7 +101,7 @@ namespace yave {
     auto info = get_node_declaration<node::Vec3>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Vec3Constructor>(),
       info.description())};
@@ -113,7 +113,7 @@ namespace yave {
     auto info = get_node_declaration<node::Vec4>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Vec4Constructor>(),
       info.description())};

--- a/src/yave/module/std/image/image.cpp
+++ b/src/yave/module/std/image/image.cpp
@@ -68,7 +68,7 @@ namespace yave {
     auto info = get_node_declaration<node::Image>();
 
     return std::vector {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::image::LoadImage>(mngr.get_pool_object()),
       info.description())};

--- a/src/yave/module/std/list/list.cpp
+++ b/src/yave/module/std/list/list.cpp
@@ -98,7 +98,7 @@ namespace yave {
   {
     auto info = get_node_declaration<node::ListNil>();
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<yave::modules::_std::list::ListNil>(),
       info.name())};
@@ -109,7 +109,7 @@ namespace yave {
   {
     auto info = get_node_declaration<node::ListCons>();
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<yave::modules::_std::list::ListCons>(),
       info.name())};
@@ -121,7 +121,7 @@ namespace yave {
     auto info = get_node_declaration<node::ListDecompose>();
 
     auto d1 = node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<yave::modules::_std::list::ListHead>(),
       info.description());

--- a/src/yave/module/std/logic/apply.cpp
+++ b/src/yave/module/std/logic/apply.cpp
@@ -39,7 +39,7 @@ namespace yave {
     auto info = get_node_declaration<node::Apply>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::logic::Apply>(),
       info.description())};

--- a/src/yave/module/std/logic/if.cpp
+++ b/src/yave/module/std/logic/if.cpp
@@ -45,6 +45,9 @@ namespace yave {
   {
     auto info = get_node_declaration<node::If>();
     return {node_definition(
-      info.name(), 0, make_object<modules::_std::logic::If>(), info.name())};
+      info.qualified_name(),
+      0,
+      make_object<modules::_std::logic::If>(),
+      info.name())};
   }
 } // namespace yave

--- a/src/yave/module/std/primitive/primitive.cpp
+++ b/src/yave/module/std/primitive/primitive.cpp
@@ -44,7 +44,7 @@ namespace yave {
     auto info = get_node_declaration<node::DataTypeConstructor<T>>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::prim::DataTypeConstructor<T>>(),
       info.name())};

--- a/src/yave/module/std/render/frame.cpp
+++ b/src/yave/module/std/render/frame.cpp
@@ -23,7 +23,7 @@ namespace yave {
   {
     auto info = get_node_declaration<node::Frame>();
     return std::vector {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::render::FrameBufferConstructor>(
         mngr.get_pool_object()),

--- a/src/yave/module/std/time/set_time.cpp
+++ b/src/yave/module/std/time/set_time.cpp
@@ -48,7 +48,7 @@ namespace yave {
     auto info = get_node_declaration<node::SetTime>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::time::SetTime>(),
       info.description())};

--- a/src/yave/module/std/time/time.cpp
+++ b/src/yave/module/std/time/time.cpp
@@ -41,7 +41,7 @@ namespace yave {
     auto info = get_node_declaration<node::Time>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::time::TimeConstructor>(),
       "Construct Time fromt Time")};

--- a/src/yave/module/std/transform/rotate.cpp
+++ b/src/yave/module/std/transform/rotate.cpp
@@ -166,7 +166,7 @@ namespace yave {
     auto info = get_node_declaration<node::Rotate>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Rotate>(),
       info.description())};
@@ -178,7 +178,7 @@ namespace yave {
     auto info = get_node_declaration<node::RotateX>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::RotateX>(),
       info.description())};
@@ -190,7 +190,7 @@ namespace yave {
     auto info = get_node_declaration<node::RotateY>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::RotateY>(),
       info.description())};
@@ -202,7 +202,7 @@ namespace yave {
     auto info = get_node_declaration<node::RotateZ>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::RotateZ>(),
       info.description())};

--- a/src/yave/module/std/transform/set_transform.cpp
+++ b/src/yave/module/std/transform/set_transform.cpp
@@ -47,7 +47,7 @@ namespace yave {
     auto info = get_node_declaration<node::SetTransform>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::SetTransform>(),
       info.description())};

--- a/src/yave/module/std/transform/transform.cpp
+++ b/src/yave/module/std/transform/transform.cpp
@@ -40,7 +40,7 @@ namespace yave {
     auto info = get_node_declaration<node::Transform>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::TransformConstructor>(),
       info.description())};

--- a/src/yave/module/std/transform/translate.cpp
+++ b/src/yave/module/std/transform/translate.cpp
@@ -63,7 +63,7 @@ namespace yave {
     auto info = get_node_declaration<node::Translate>();
 
     return {node_definition(
-      info.name(),
+      info.qualified_name(),
       0,
       make_object<modules::_std::geometry::Translate>(),
       info.description())};

--- a/src/yave/node/compiler/node_compiler.cpp
+++ b/src/yave/node/compiler/node_compiler.cpp
@@ -384,86 +384,6 @@ namespace yave {
   auto node_compiler::impl::desugar(structured_node_graph&& ng, int)
     -> tl::optional<structured_node_graph>
   {
-    struct
-    {
-      // Add Variables on empty input socket of lambda calls
-      void fill_variables(const node_handle& n, structured_node_graph& ng)
-      {
-        assert(ng.is_group(n));
-        if (ng.input_connections(n).size() < ng.input_sockets(n).size())
-          for (auto&& s : ng.input_sockets(n))
-            ng.set_data(s, make_object<Variable>());
-      }
-
-      // Rmove unsued default socket data
-      void omit_unused_defaults(const node_handle& n, structured_node_graph& ng)
-      {
-        assert(ng.is_function(n));
-        for (auto&& s : ng.input_sockets(n))
-          if (!ng.connections(s).empty())
-            ng.set_data(s, nullptr);
-      }
-
-      void rec_g(
-        const node_handle& g,
-        const socket_handle& os,
-        structured_node_graph& ng)
-      {
-        fill_variables(g, ng);
-
-        // inputs
-        for (auto&& c : ng.input_connections(g)) {
-          auto ci = ng.get_info(c);
-          rec_n(ci->src_node(), ci->src_socket(), ng);
-        }
-
-        // inside
-        {
-          auto go  = ng.get_group_output(g);
-          auto idx = *ng.get_index(os);
-          auto s   = ng.input_sockets(go)[idx];
-
-          for (auto&& c : ng.connections(s)) {
-            auto ci = ng.get_info(c);
-            rec_n(ci->src_node(), ci->src_socket(), ng);
-          }
-        }
-      }
-
-      void rec_f(
-        const node_handle& f,
-        const socket_handle& os,
-        structured_node_graph& ng)
-      {
-        (void)os;
-
-        omit_unused_defaults(f, ng);
-
-        // inputs
-        for (auto&& c : ng.input_connections(f)) {
-          auto ci = ng.get_info(c);
-          rec_n(ci->src_node(), ci->src_socket(), ng);
-        }
-      }
-
-      void rec_n(
-        const node_handle& n,
-        const socket_handle& os,
-        structured_node_graph& ng)
-      {
-        if (ng.is_group(n))
-          return rec_g(n, os, ng);
-
-        if (ng.is_function(n))
-          return rec_f(n, os, ng);
-
-        if (ng.is_group_input(n))
-          return;
-
-        assert(false);
-      }
-    } impl;
-
     auto roots = ng.search_path("/");
 
     auto root = [&] {
@@ -476,7 +396,74 @@ namespace yave {
     assert(ng.output_sockets(root).size() == 1);
     auto rootos = ng.output_sockets(root)[0];
 
-    impl.rec_n(root, rootos, ng);
+    // Add Variables on empty input socket of lambda calls
+    auto fill_variables = [](const auto& n, auto& ng) {
+      assert(ng.is_group(n));
+      if (ng.input_connections(n).size() < ng.input_sockets(n).size())
+        for (auto&& s : ng.input_sockets(n))
+          ng.set_data(s, make_object<Variable>());
+    };
+
+    // Rmove unsued default socket data
+    auto omit_unused_defaults = [](const auto& n, auto& ng) {
+      assert(ng.is_function(n));
+      for (auto&& s : ng.input_sockets(n))
+        if (!ng.connections(s).empty())
+          ng.set_data(s, nullptr);
+    };
+
+    // for group
+    auto rec_g = [&](auto&& rec_n, const auto& g, const auto& os) -> void {
+      // fill
+      fill_variables(g, ng);
+
+      // inputs
+      for (auto&& c : ng.input_connections(g)) {
+        auto ci = ng.get_info(c);
+        rec_n(ci->src_node(), ci->src_socket());
+      }
+
+      // inside
+      {
+        auto go  = ng.get_group_output(g);
+        auto idx = *ng.get_index(os);
+        auto s   = ng.input_sockets(go)[idx];
+
+        for (auto&& c : ng.connections(s)) {
+          auto ci = ng.get_info(c);
+          rec_n(ci->src_node(), ci->src_socket());
+        }
+      }
+    };
+
+    // for function
+    auto rec_f = [&](auto&& rec_n, const auto& f) -> void {
+      // omit
+      omit_unused_defaults(f, ng);
+
+      // inputs
+      for (auto&& c : ng.input_connections(f)) {
+        auto ci = ng.get_info(c);
+        rec_n(ci->src_node(), ci->src_socket());
+      }
+    };
+
+    // general
+    auto rec_n = [&](auto&& self, const auto& n, const auto& os) {
+      if (ng.is_group(n))
+        return rec_g(self, n, os);
+
+      if (ng.is_function(n))
+        return rec_f(self, n);
+
+      if (ng.is_group_input(n))
+        return;
+
+      assert(false);
+    };
+
+    auto rec = fix_lambda(rec_n);
+    rec(root, rootos);
 
     return std::move(ng);
   }
@@ -486,153 +473,6 @@ namespace yave {
     const node_definition_store& defs)
     -> tl::optional<std::pair<object_ptr<const Object>, class_env>>
   {
-    struct
-    {
-      auto get_function_body(
-        const node_handle& f,
-        const socket_handle& os,
-        const node_definition_store& defs,
-        const structured_node_graph& ng,
-        class_env& env)
-      {
-        assert(ng.is_function(f));
-
-        auto ds = defs.get_binds(*ng.get_name(f), *ng.get_index(os));
-
-        if (ds.empty())
-          throw compile_error::no_valid_overloading(f, os);
-
-        std::vector<object_ptr<const Object>> insts;
-        insts.reserve(defs.size());
-
-        for (auto&& d : ds)
-          insts.push_back(d->instance());
-
-        return insts.size() == 1 ? insts[0] : env.add_overloading(insts);
-      }
-
-      auto rec_g(
-        const node_handle& g,
-        const socket_handle& os,
-        const std::vector<object_ptr<const Object>>& in,
-        const node_definition_store& defs,
-        structured_node_graph& ng,
-        class_env& env)
-      {
-        assert(ng.is_group(g));
-
-        // inputs
-        std::vector<object_ptr<const Object>> ins;
-        for (auto&& s : ng.input_sockets(g)) {
-
-          // variable
-          if (auto data = ng.get_data(s)) {
-            assert(ng.connections(s).empty());
-            ins.push_back(data);
-            continue;
-          }
-
-          assert(ng.connections(s).size() == 1);
-          auto ci = ng.get_info(ng.connections(s)[0]);
-          ins.push_back(
-            rec_n(ci->src_node(), ci->src_socket(), in, defs, ng, env));
-        }
-
-        // inside
-        object_ptr<const Object> ret;
-        {
-          auto go  = ng.get_group_output(g);
-          auto idx = *ng.get_index(os);
-          auto s   = ng.input_sockets(go)[idx];
-
-          assert(ng.connections(s).size() == 1);
-
-          auto ci = ng.get_info(ng.connections(s)[0]);
-          ret     = rec_n(ci->src_node(), ci->src_socket(), ins, defs, ng, env);
-        }
-
-        // add Lambda
-        for (auto&& i : ins | rv::reverse)
-          if (auto var = value_cast_if<Variable>(i))
-            ret = make_object<Lambda>(var, ret);
-
-        return ret;
-      }
-
-      auto rec_i(
-        const node_handle& i,
-        const socket_handle& os,
-        const std::vector<object_ptr<const Object>>& in,
-        structured_node_graph& ng)
-      {
-        assert(ng.is_group_input(i));
-
-        auto idx = *ng.get_index(os);
-        return in[idx];
-      }
-
-      auto rec_f(
-        const node_handle& f,
-        const socket_handle& os,
-        const std::vector<object_ptr<const Object>>& in,
-        const node_definition_store& defs,
-        structured_node_graph& ng,
-        class_env& env)
-      {
-        (void)os;
-        assert(ng.is_function(f));
-
-        auto body = get_function_body(f, os, defs, ng, env);
-
-        for (auto&& s : ng.input_sockets(f)) {
-
-          // default value
-          if (auto data = ng.get_data(s)) {
-
-            // FIXME: Remove this branch
-            if (auto holder = value_cast_if<DataTypeHolder>(data))
-              body = body << holder->get_data_constructor();
-            else
-              body = body << data;
-
-            continue;
-          }
-
-          auto cs = ng.connections(s);
-
-          // lambda
-          if (cs.empty())
-            return body;
-
-          auto ci = ng.get_info(cs[0]);
-          body =
-            body << rec_n(ci->src_node(), ci->src_socket(), in, defs, ng, env);
-        }
-
-        return body;
-      }
-
-      auto rec_n(
-        const node_handle& n,
-        const socket_handle& os,
-        const std::vector<object_ptr<const Object>>& in,
-        const node_definition_store& defs,
-        structured_node_graph& ng,
-        class_env& env) -> object_ptr<const Object>
-      {
-        if (ng.is_group(n))
-          return rec_g(n, os, in, defs, ng, env);
-
-        if (ng.is_function(n))
-          return rec_f(n, os, in, defs, ng, env);
-
-        if (ng.is_group_input(n))
-          return rec_i(n, os, in, ng);
-
-        assert(false);
-      }
-    } impl;
-
     auto roots = ng.search_path("/");
 
     auto root = [&] {
@@ -645,15 +485,144 @@ namespace yave {
     assert(ng.output_sockets(root).size() == 1);
     auto rootos = ng.output_sockets(root)[0];
 
+    // class overload environment
+    class_env env;
+
+    // get overloaded function
+    auto get_function_body = [&](const auto& f, const auto& os) {
+      assert(ng.is_function(f));
+
+      auto ds = defs.get_binds(*ng.get_name(f), *ng.get_index(os));
+
+      if (ds.empty())
+        throw compile_error::no_valid_overloading(f, os);
+
+      std::vector<object_ptr<const Object>> insts;
+      insts.reserve(defs.size());
+
+      for (auto&& d : ds)
+        insts.push_back(d->instance());
+
+      return insts.size() == 1 ? insts[0] : env.add_overloading(insts);
+    };
+
+    // group
+    auto rec_g = [&](
+                   auto&& rec_n,
+                   const auto& g,
+                   const auto& os,
+                   const auto& in) -> object_ptr<const Object> {
+      assert(ng.is_group(g));
+
+      Info(g_logger, "rec_g: {}", *ng.get_name(g));
+
+      // inputs
+      std::vector<object_ptr<const Object>> ins;
+      for (auto&& s : ng.input_sockets(g)) {
+
+        // variable
+        if (auto data = ng.get_data(s)) {
+          assert(ng.connections(s).empty());
+          ins.push_back(data);
+          continue;
+        }
+
+        assert(ng.connections(s).size() == 1);
+        auto ci = ng.get_info(ng.connections(s)[0]);
+        ins.push_back(rec_n(ci->src_node(), ci->src_socket(), in));
+      }
+
+      // inside
+      object_ptr<const Object> ret;
+      {
+        auto go  = ng.get_group_output(g);
+        auto idx = *ng.get_index(os);
+        auto s   = ng.input_sockets(go)[idx];
+
+        assert(ng.connections(s).size() == 1);
+
+        auto ci = ng.get_info(ng.connections(s)[0]);
+        ret     = rec_n(ci->src_node(), ci->src_socket(), ins);
+      }
+
+      // add Lambda
+      for (auto&& i : ins | rv::reverse)
+        if (auto var = value_cast_if<Variable>(i))
+          ret = make_object<Lambda>(var, ret);
+
+      return ret;
+    };
+
+    // function
+    auto rec_f = [&](
+                   auto&& rec_n,
+                   const auto& f,
+                   const auto& os,
+                   const auto& in) -> object_ptr<const Object> {
+      (void)os;
+      assert(ng.is_function(f));
+
+      Info(g_logger, "rec_f: {}", *ng.get_name(f));
+
+      auto body = get_function_body(f, os);
+
+      for (auto&& s : ng.input_sockets(f)) {
+
+        // default value
+        if (auto data = ng.get_data(s)) {
+
+          // FIXME: Remove this branch
+          if (auto holder = value_cast_if<DataTypeHolder>(data))
+            body = body << holder->get_data_constructor();
+          else
+            body = body << data;
+
+          continue;
+        }
+
+        auto cs = ng.connections(s);
+
+        // lambda
+        if (cs.empty())
+          return body;
+
+        auto ci = ng.get_info(cs[0]);
+        body    = body << rec_n(ci->src_node(), ci->src_socket(), in);
+      }
+
+      return body;
+    };
+
+    // group input
+    auto rec_i = [&](const auto& i, const auto& os, const auto& in) {
+      assert(ng.is_group_input(i));
+      auto idx = *ng.get_index(os);
+      return in[idx];
+    };
+
+    // general
+    auto rec_n =
+      [&](auto&& self, const auto& n, const auto& os, const auto& in) {
+        if (ng.is_group(n))
+          return rec_g(self, n, os, in);
+
+        if (ng.is_function(n))
+          return rec_f(self, n, os, in);
+
+        if (ng.is_group_input(n))
+          return rec_i(n, os, in);
+
+        assert(false);
+      };
+
     // FIXME:
     node_handle srcn;
     socket_handle srcs;
 
     try {
 
-      class_env env;
-      auto app = impl.rec_n(root, rootos, {}, defs, ng, env);
-
+      auto rec = fix_lambda(rec_n);
+      auto app = rec(root, rootos, std::vector<object_ptr<const Object>>());
       return std::make_pair(std::move(app), std::move(env));
 
       // forward

--- a/src/yave/node/compiler/type.cpp
+++ b/src/yave/node/compiler/type.cpp
@@ -9,13 +9,14 @@
 namespace yave {
 
   auto class_env::add_overloading(
+    const uid& id,
     const std::vector<object_ptr<const Object>>& instances)
     -> object_ptr<const Overloaded>
   {
-    auto src = make_object<Overloaded>();
-    auto id  = src->id_var;
+    auto src    = make_object<Overloaded>(id.data);
+    auto id_var = src->id_var;
 
-    if (m_map.find(id) != m_map.end())
+    if (m_map.find(id_var) != m_map.end())
       throw std::invalid_argument("Class is already defined");
 
     // calculate generalized type
@@ -48,9 +49,21 @@ namespace yave {
     }
 
     // add
-    m_map.emplace(id, overloaded_class {gentp, instances});
+    m_map.emplace(id_var, overloaded_class {gentp, instances});
 
     return src;
+  }
+
+  auto class_env::find_overloaded(const uid& id) const
+    -> object_ptr<const Overloaded>
+  {
+    auto id_var = make_object<Type>(var_type {id.data});
+
+    if (m_map.find(id_var) != m_map.end())
+      // always create new object
+      return make_object<Overloaded>(id.data);
+
+    return nullptr;
   }
 
   auto class_env::find_overloading(const object_ptr<const Type>& class_id) const

--- a/src/yave/node/core/node_definition_store.cpp
+++ b/src/yave/node/core/node_definition_store.cpp
@@ -44,20 +44,19 @@ namespace yave {
 
   void node_definition_store::add(const node_definition& def)
   {
-    m_map.emplace(def.name(), std::make_shared<node_definition>(def));
+    m_map.emplace(def.qualified_name(), std::make_shared<node_definition>(def));
 
     Info(
       g_logger,
       "Added new definition: name={}, os={}",
-      def.name(),
+      def.qualified_name(),
       def.output_socket());
   }
 
   void node_definition_store::add(const std::vector<node_definition>& defs)
   {
-    for (auto&& def : defs) {
+    for (auto&& def : defs)
       add(def);
-    }
   }
 
   void node_definition_store::remove(const std::string& name)

--- a/test/node/compiler/compiler.cpp
+++ b/test/node/compiler/compiler.cpp
@@ -506,7 +506,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(
       graph.connect(graph.output_sockets(i2)[0], graph.input_sockets(add)[1]));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add x x")
@@ -524,7 +524,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(
       graph.connect(graph.output_sockets(i)[0], graph.input_sockets(add)[1]));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add (add x x) x")
@@ -552,7 +552,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, add2_x));
     REQUIRE(graph.connect(i_value, add2_y));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add x d")
@@ -575,7 +575,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, add_x));
     REQUIRE(graph.connect(d_value, add_y));
 
-    REQUIRE(!compiler.compile(std::move(graph), defs));
+    REQUIRE(!compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add (add x d) x")
@@ -605,7 +605,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, add2_x));
     REQUIRE(graph.connect(d_value, add2_y));
 
-    REQUIRE(!compiler.compile(std::move(graph), defs));
+    REQUIRE(!compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("if b x y")
@@ -630,7 +630,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, _if_then));
     REQUIRE(graph.connect(i_value, _if_else));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("if b (if b x y) z")
@@ -666,7 +666,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, if2_else));
     REQUIRE(graph.connect(i_value, if1_else));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("if b x d")
@@ -694,7 +694,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, _if_then));
     REQUIRE(graph.connect(d_value, _if_else));
 
-    REQUIRE(!compiler.compile(std::move(graph), defs));
+    REQUIRE(!compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add<int> x y")
@@ -714,7 +714,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, add_x));
     REQUIRE(graph.connect(i_value, add_y));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add<double> x y")
@@ -734,7 +734,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(d_value, add_x));
     REQUIRE(graph.connect(d_value, add_y));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("add<?> x y")
@@ -757,7 +757,7 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, add_x));
     REQUIRE(graph.connect(d_value, add_y));
 
-    REQUIRE(!compiler.compile(std::move(graph), defs));
+    REQUIRE(!compiler.compile(std::move(graph), decls, defs));
   }
 
   SECTION("42 : []")
@@ -780,6 +780,6 @@ TEST_CASE("add", "[node_compiler]")
     REQUIRE(graph.connect(i_value, cons_head));
     REQUIRE(graph.connect(nil_value, cons_tail));
 
-    REQUIRE(compiler.compile(std::move(graph), defs));
+    REQUIRE(compiler.compile(std::move(graph), decls, defs));
   }
 }

--- a/test/node/compiler/compiler.cpp
+++ b/test/node/compiler/compiler.cpp
@@ -48,7 +48,7 @@ struct yave::node_declaration_traits<n::Add>
   static auto get_node_declaration()
   {
     class X;
-    return node_declaration("add", "/test", "", {"x", "y"}, {"out"});
+    return node_declaration("Add", "/test", "", {"x", "y"}, {"out"});
   }
 };
 
@@ -59,11 +59,17 @@ struct yave::node_definition_traits<n::Add, test_backend>
   {
     // Int version
     auto defi = node_definition(
-      get_node_declaration<n::Add>().name(), 0, make_object<AddI>(), "AddI");
+      get_node_declaration<n::Add>().qualified_name(),
+      0,
+      make_object<AddI>(),
+      "AddI");
 
     // Float version
     auto defd = node_definition(
-      get_node_declaration<n::Add>().name(), 0, make_object<AddF>(), "AddF");
+      get_node_declaration<n::Add>().qualified_name(),
+      0,
+      make_object<AddF>(),
+      "AddF");
 
     return {defi, defd};
   }
@@ -376,7 +382,7 @@ TEST_CASE("node_compiler V2")
   SECTION("f = [x y -> x + y]")
   {
     auto f = ng.create_group(root);
-    ng.set_name(f, "/x y -> x + y");
+    ng.set_name(f, "(x y -> x + y)");
     auto a = ng.create_copy(f, add_func);
     REQUIRE(ng.add_output_socket(f, "out"));
     REQUIRE(ng.add_input_socket(f, "x"));

--- a/test/node/compiler/type.cpp
+++ b/test/node/compiler/type.cpp
@@ -27,7 +27,7 @@ TEST_CASE("overloading")
     auto id = make_object<Identity>();
 
     class_env env;
-    auto o = env.add_overloading({f});
+    auto o = env.add_overloading(uid::random_generate(), {f});
 
     SECTION("f 42")
     {
@@ -105,7 +105,7 @@ TEST_CASE("overloading")
     auto id = make_object<Identity>();
 
     class_env env;
-    auto o = env.add_overloading({f, g});
+    auto o = env.add_overloading(uid::random_generate(), {f, g});
 
     SECTION("(id f) (f 42)")
     {
@@ -197,7 +197,7 @@ TEST_CASE("overloading")
     auto id = make_object<Identity>();
 
     class_env env;
-    auto ovl = env.add_overloading({j, i, h, g, f});
+    auto ovl = env.add_overloading(uid::random_generate(), {j, i, h, g, f});
 
     SECTION("f Int")
     {
@@ -301,7 +301,7 @@ TEST_CASE("overloading")
     auto id = make_object<Identity>();
 
     class_env env;
-    auto o = env.add_overloading({f, g});
+    auto o = env.add_overloading(uid::random_generate(), {f, g});
 
     SECTION("f Int")
     {
@@ -387,7 +387,7 @@ TEST_CASE("overloading")
     SECTION("2")
     {
       class_env env;
-      auto overloaded = env.add_overloading({f, g});
+      auto overloaded = env.add_overloading(uid::random_generate(), {f, g});
 
       auto app = overloaded << (overloaded << h);
 


### PR DESCRIPTION
Current lookup of node definition is based on it's name (i.e. `Int`, `Float`, etc.).
This PR changed name lookup using qualified name with namespace (ex. `/std/prim/Int`).