### PR TITLE
Make Undo/Redo usable

### DIFF
--- a/src/yave-imgui/node_window.cpp
+++ b/src/yave-imgui/node_window.cpp
@@ -389,7 +389,7 @@ namespace yave::editor::imgui {
           make_window_view_command(*this, [](auto& w) { w.clear_selected(); }));
       }
 
-      // Ctrol + U = move to upper group
+      // Ctrl + U = move to upper group
       if (
         ImGui::IsKeyDown(GLFW_KEY_LEFT_CONTROL) && //
         ImGui::IsKeyPressed(GLFW_KEY_U)) {
@@ -407,6 +407,18 @@ namespace yave::editor::imgui {
             w.set_group(ng.get_parent_group(g));
           }));
       }
+
+      // Ctrl + Z = undo
+      if (
+        ImGui::IsKeyDown(GLFW_KEY_LEFT_CONTROL) && //
+        ImGui::IsKeyPressed(GLFW_KEY_Z))
+        dctx.undo();
+
+      // Ctrl + R = redo
+      if (
+        ImGui::IsKeyDown(GLFW_KEY_LEFT_CONTROL) && //
+        ImGui::IsKeyPressed(GLFW_KEY_R))
+        dctx.redo();
     }
   }
 


### PR DESCRIPTION
Enable undo/redo feature
* `Ctrl + Z` for undo
* `Ctrl + R` for redo

Known issues:
* [ ] Some operations are missing undo implementation
  + Ungrouping is not implemented in node library yet
* [ ] Redo does not work on `connect()` operation
  - [x] We need to support creating nodes and connections with custom ID, which is not really that hard I guess.
* [ ] Undo for deletion of node group can be complex since it can contain sub-groups.
* [ ] How do we restore default input values? Just store values in command history (which can take some memory)?
* [ ] Should we capture node/socket changes, select, move?